### PR TITLE
Fix strings showing HTML entities instead of characters

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,5 +1,6 @@
 var request = require("request");
 var fs = require('fs');
+var unescapeHTML = require('underscore.string/unescapeHTML');
 
 var base = {
 	sourceUrl: "http://www.qtworldsummit.com/sessionsjson/", //http://localhost/2015.json",
@@ -111,14 +112,14 @@ function __formatMilitaryTime(time) {
 				"tracks" : timeMap[t[k]].map(function(e) { 
 					var ee = {
 						"id" : e.session_id,
-						"title" : decodeURIComponent(e.session_title),
+						"title" : unescapeHTML(e.session_title),
 						"location" : (e.session_room || "").toUpperCase(),
 						"presenter" : [e.session_speaker_name, e.session_speaker_company].filter(Boolean).join(", ")
 					}
 					detail[e.session_id] = {
 						"id" : ee.id,
 						"presentation" : {
-							"title" : ee.title,
+							"title" : unescapeHTML(ee.title),
 							"abstract" : e.session_abstract,
 							"track" : {
 								// ..?

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "express": "latest",
     "redis" : "latest",
-    "request" : "latest"
+    "request" : "latest",
+    "underscore.string": "^3.1.1"
   }
 }


### PR DESCRIPTION
Use underscore.string to unescape html entities

Before
    What&#8217;s new in C++11/C++14? (with a Qt5 focus)

After
    What's new in C++11/C++14? (with a Qt5 focus)
